### PR TITLE
Get window bug

### DIFF
--- a/pBoard.pde
+++ b/pBoard.pde
@@ -1,10 +1,13 @@
+
 //Scott Little 2015, GPLv3
 //pBoard is Processing for Cardboard
 
-import android.os.Bundle;  //for 
+import android.os.Bundle;  //for
+import android.app.Activity;
 import android.view.WindowManager;
 import ketai.sensors.*;  //ketai library for sensors
 KetaiSensor sensor;
+Activity act;
 
 float ax,ay,az,mx,my,mz;  //sensor variables
 float eyex = 50; //camera variables
@@ -22,7 +25,8 @@ PShape s; //the object to be displayed
 void onCreate(Bundle savedInstanceState) {
   super.onCreate(savedInstanceState);
   // fix so screen doesn't go to sleep when app is active
-  //getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+  act = this.getActivity();
+  act.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 }
 //********************************************************************
 
@@ -31,7 +35,7 @@ void setup() {
   sensor.start();
   
   size(displayWidth,displayHeight,P3D);  //used to set P3D renderer
-  //orientation(LANDSCAPE);  //causes crashing if not started in this orientation
+  orientation(LANDSCAPE);  //causes crashing if not started in this orientation
   
   lv = createGraphics(displayWidth/2,displayHeight,P3D); //size of left viewport
   rv = createGraphics(displayWidth/2,displayHeight,P3D);

--- a/pBoard.pde
+++ b/pBoard.pde
@@ -22,7 +22,7 @@ PShape s; //the object to be displayed
 void onCreate(Bundle savedInstanceState) {
   super.onCreate(savedInstanceState);
   // fix so screen doesn't go to sleep when app is active
-  getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+  //getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 }
 //********************************************************************
 


### PR DESCRIPTION
Hey. Thanks for this very useful code.
Sketch would not start because of the "prevent sleep" trick. `getWindow` was not recognized.
Using [this forum post(https://forum.processing.org/two/discussion/comment/68228/#Comment_68228) a guideline, I updated the code so now the "no sleep trick" works. 
I've only tested in Android-23.
Hope it helps.
(Sorry, it's kind of a messy pull request)
